### PR TITLE
(fix) refactors limited bash scripting

### DIFF
--- a/webshell/run.sh
+++ b/webshell/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-if [ -z "${GOTTY_CREDENTIALS}" ]; then
-  /usr/local/bin/gotty -w --reconnect /bin/bash
-else
-  /usr/local/bin/gotty -w --reconnect -c "${GOTTY_CREDENTIALS}" /bin/bash
-fi
+GOTTY=$(which gotty || /usr/local/bin/gotty)
+
+[ -z "${GOTTY_CREDENTIALS}" ] && OPTS="-c ${GOTTY_CREDENTIALS}"
+${GOTTY} -w --reconnect ${OPTS} $@ /bin/bash


### PR DESCRIPTION
Changes:
  - POSIX friendly script
  - checks $PATH first
  - Single call to gotty
  - tests for env then sets environment flag $OPTS
  - Allow end user to add options by overriding $OPTS or passing from docker CMD statement